### PR TITLE
미사용 Google Maps geo.API_KEY meta-data 제거 (#99)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -35,9 +35,6 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
-        <meta-data
-            android:name="com.google.android.geo.API_KEY"
-            android:value="YOUR_GOOGLE_MAPS_API_KEY"/>
     </application>
 
 </manifest>


### PR DESCRIPTION
## ✨ 작업 내용
미사용 `com.google.android.geo.API_KEY` meta-data 제거. Closes #99

- 조사 결과 앱은 Google Maps **렌더링을 쓰지 않는다**(지도 렌더링은 Naver `NaverMapScreen`, Google 은 Places 만 사용 — Places 는 `R.string.maps_api_key` resValue 로 초기화되며 매니페스트 `geo.API_KEY` 와 무관).
- 따라서 `com.google.android.geo.API_KEY = YOUR_GOOGLE_MAPS_API_KEY` 는 아무것도 읽지 않는 dead placeholder → 제거.
- (#99 는 원래 "실제 키 주입"으로 열렸으나, 미사용을 확인 후 이슈 Note 의 "미사용이면 제거" 옵션으로 처리)

## 📸 스크린샷 (선택)
- 해당 없음 (매니페스트 정리)

## 🧪 테스트 방법
- `./gradlew :app:lintDebug` → BUILD SUCCESSFUL (제거 후 빌드·lint 정상 확인)

## 📝 TODO
- 향후 Google Maps 렌더링(maps-compose)을 실제로 쓰게 되면 `${MAPS_API_KEY}` manifestPlaceholder 로 다시 추가(Naver `NCP_KEY_ID` 방식)

---

### ✅ PR 타입
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] UI 개선
- [x] 리팩토링
- [ ] 문서 작성

---

### 🔁 기타 참고 사항
- 남은 보안 follow-up: **#98**(Maps 키 로테이션 + 패키지/SHA-1·API 제한)은 Google Cloud Console 수동 작업.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
