### PR TITLE
build.gradle.kts 의존성 정리 + Gradle/AGP/Kotlin 업그레이드 (#106)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -12,7 +12,7 @@ secrets {
     defaultPropertiesFileName = "local.defaults.properties"
 }
 
-// secrets.properties(gitignored) 우선, 없으면 local.defaults.properties 로 폴백해서 읽는다.
+// secrets.properties(gitignore 대상) 우선, 없으면 local.defaults.properties 로 폴백해서 읽는다.
 // secrets-gradle-plugin 은 manifestPlaceholder 만 주입하므로, R.string 으로 소비되는 값은 여기서 resValue 로 생성한다.
 val localSecrets = Properties().apply {
     rootProject.file("local.defaults.properties").takeIf { it.exists() }?.inputStream()?.use { load(it) }
@@ -75,7 +75,7 @@ dependencies {
     implementation(libs.androidx.ui)
     implementation(libs.androidx.ui.graphics)
     implementation(libs.androidx.ui.tooling.preview)
-    implementation(libs.androidx.material3)
+    implementation(libs.material3)
     implementation(libs.androidx.navigation.compose)
 
     implementation(libs.play.services.auth)
@@ -89,10 +89,6 @@ dependencies {
     implementation(libs.androidx.lifecycle.livedata.ktx)
     implementation(libs.androidx.runtime.livedata)
     implementation(libs.androidx.material)
-    implementation(libs.play.services.maps)
-    implementation(libs.maps.compose) // 새로고침 기능
-
-    implementation(libs.androidx.material)
     implementation(libs.firebase.common.ktx)
     implementation(libs.places)
     implementation(libs.material)
@@ -101,7 +97,17 @@ dependencies {
     implementation(libs.firebase.functions.ktx)
     implementation(libs.map.sdk)
     implementation(libs.naver.map.compose)
-    implementation(libs.material3) // 새로고침 기능
+
+    // Firebase (BOM 으로 버전 관리)
+    implementation(platform(libs.firebase.bom))
+    implementation(libs.firebase.analytics)
+    implementation(libs.firebase.auth.ktx)
+    // firestore-ktx 는 BOM 관리 — 카탈로그 alias(25.1.4)로 옮기면 버전 변동 위험이라 좌표 유지
+    implementation("com.google.firebase:firebase-firestore-ktx")
+
+    implementation(libs.play.services.location)
+    implementation(libs.gson)
+
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
@@ -109,27 +115,4 @@ dependencies {
     androidTestImplementation(libs.androidx.ui.test.junit4)
     debugImplementation(libs.androidx.ui.tooling)
     debugImplementation(libs.androidx.ui.test.manifest)
-    implementation(platform("com.google.firebase:firebase-bom:33.13.0"))
-    implementation("com.google.firebase:firebase-analytics")
-    implementation("com.google.firebase:firebase-auth-ktx")             // 로그인 기능
-    implementation("com.google.firebase:firebase-firestore-ktx")       // DB 기능
-    implementation("androidx.core:core-ktx:1.12.0")
-    implementation("androidx.activity:activity-compose:1.8.0") // 이게 가장 중요!
-    implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.6.2") // ViewModel 등을 쓸 경우
-    // 아래는 Compose 쓸 때 기본적으로 같이 사용합니다
-    implementation("androidx.compose.ui:ui:1.5.4")
-    implementation("androidx.compose.material:material:1.5.4")
-    implementation("androidx.compose.ui:ui-tooling-preview:1.5.4")
-    implementation("androidx.navigation:navigation-compose:2.7.5")
-    implementation ("androidx.lifecycle:lifecycle-viewmodel-compose:2.6.1")
-    implementation ("com.google.android.gms:play-services-maps:18.1.0")
-
-    implementation ("com.google.android.gms:play-services-location:21.0.1")
-    // ✅ JSON 파싱을 위한 Gson
-    implementation("com.google.code.gson:gson:2.10.1")
-
-    implementation("com.naver.maps:map-sdk:3.21.0")
-    implementation(libs.naver.map.compose)
-    implementation("androidx.compose.material3:material3:1.2.1")
-
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,3 +21,13 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
+android.defaults.buildfeatures.resvalues=true
+android.sdk.defaultTargetSdkToCompileSdkIfUnset=false
+android.enableAppCompileTimeRClass=false
+android.usesSdkInManifest.disallowed=false
+android.uniquePackageNames=false
+android.dependency.useConstraints=true
+android.r8.strictFullModeForKeepRules=false
+android.r8.optimizedResourceShrinking=false
+android.builtInKotlin=false
+android.newDsl=false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
-agp = "8.13.2"
-kotlin = "2.0.21"
+agp = "9.2.1"
+kotlin = "2.2.10"
 coreKtx = "1.15.0"
 junit = "4.13.2"
 junitVersion = "1.2.1"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -35,6 +35,9 @@ firebaseFunctionsKtx = "21.2.1"
 mapSdk = "3.21.0"
 naverMapCompose = "1.8.0"
 material3 = "1.3.2"
+firebaseBom = "33.13.0"
+playServicesLocation = "21.0.1"
+gson = "2.10.1"
 
 
 [libraries]
@@ -82,6 +85,11 @@ firebase-functions-ktx = { group = "com.google.firebase", name = "firebase-funct
 map-sdk = { group = "com.naver.maps", name = "map-sdk", version.ref = "mapSdk" }
 naver-map-compose = { group = "io.github.fornewid", name = "naver-map-compose", version.ref = "naverMapCompose" }
 material3 = { group = "androidx.compose.material3", name = "material3", version.ref = "material3" }
+firebase-bom = { group = "com.google.firebase", name = "firebase-bom", version.ref = "firebaseBom" }
+firebase-analytics = { group = "com.google.firebase", name = "firebase-analytics" }
+firebase-auth-ktx = { group = "com.google.firebase", name = "firebase-auth-ktx" }
+play-services-location = { group = "com.google.android.gms", name = "play-services-location", version.ref = "playServicesLocation" }
+gson = { group = "com.google.code.gson", name = "gson", version.ref = "gson" }
 
 
 [plugins]

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Wed Mar 26 17:03:40 KST 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## ✨ 작업 내용
커밋 2개가 포함됩니다:

**1) 의존성 정리 — `11c17f8` (Closes #106)**
- 하드코딩 좌표 ↔ 카탈로그 alias 중복 제거 + 카탈로그 내 중복(material·naver-compose·material3) 제거 — 유효 버전 불변(로컬 `:app:assembleDebug` + 의존성 그래프로 확인)
- 미사용 Google Maps 의존성(`maps-compose`·`play-services-maps`) 제거 (지도 렌더링은 Naver, Google 은 Places 만)
- `firebase-bom`/`analytics`/`auth-ktx` · `play-services-location` · `gson` 버전 카탈로그 이전
- 주석 typo 수정

**2) Gradle / AGP / Kotlin 업그레이드 + 빌드 설정 — `50fd56b`**
- AGP `8.13.2 → 9.2.1`, Kotlin `2.0.21 → 2.2.10`, Gradle wrapper, `gradle.properties`

## 📸 스크린샷 (선택)
- 해당 없음 (빌드 설정 변경)

## 🧪 테스트 방법
- 의존성 정리(커밋 1)는 업그레이드 전 toolchain 으로 로컬 빌드 검증 완료
- **AGP 8→9 메이저 업그레이드(커밋 2)는 CI(Unit Test / Android Lint)로 검증** — 빌드 영향 주시

## 📝 TODO
- (없음)

---

### ✅ PR 타입
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] UI 개선
- [x] 리팩토링
- [ ] 문서 작성

---

### 🔁 기타 참고 사항
- **AGP 8→9 메이저 업그레이드 포함** — build-logic 컨벤션 플러그인·Gradle 호환성 등 CI 결과 확인 필요. 의존성 정리(`11c17f8`)와 별도 커밋이라, 업그레이드가 CI 를 깨면 그 커밋만 분리 가능.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
