### PR TITLE
CI green 시 PR 자동 머지 워크플로우 추가 (#108)

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,56 @@
+name: Auto-merge on green CI
+
+# PR 의 CI(Unit Test / Static Analysis)가 모두 green + mergeable 이면 서버측에서 자동 squash 머지.
+# GitHub 네이티브 auto-merge 는 repo 설정(allow_auto_merge + 브랜치 보호)이 admin 권한을 요구하므로,
+# collaborator 가 워크플로로 대체한다.
+#
+# 필요한 secret: AUTOMERGE_PAT
+#   - 1hyok 의 PAT (fine-grained, repo = danpung628/Smartee, 권한: Contents=Read/Write, Pull requests=Read/Write)
+#   - Settings → Developer settings → Personal access tokens 에서 생성 후
+#     `gh secret set AUTOMERGE_PAT -R danpung628/Smartee` 또는 repo Secrets 에 추가.
+#   - GITHUB_TOKEN 으로도 가능하지만 워크플로 기본 권한이 read-only 이면 머지 불가 → PAT 사용.
+
+on:
+  workflow_run:
+    workflows: ["Unit Test", "Static Analysis (Reviewdog)"]
+    types: [completed]
+
+jobs:
+  automerge:
+    # PR 이벤트로 돈 CI 만 대상 (push 등 제외)
+    if: github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Merge PR when all checks are green
+        env:
+          GH_TOKEN: ${{ secrets.AUTOMERGE_PAT }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          set -euo pipefail
+
+          # 이 CI 를 띄운 head 커밋의 열린 PR 찾기
+          pr=$(gh pr list -R "$REPO" --state open --json number,headRefOid \
+                 --jq "[.[] | select(.headRefOid==\"$SHA\")][0].number // empty")
+          if [ -z "$pr" ]; then
+            echo "head $SHA 에 열린 PR 없음 — skip"
+            exit 0
+          fi
+          echo "대상 PR: #$pr (head $SHA)"
+
+          mergeable=$(gh pr view "$pr" -R "$REPO" --json mergeable --jq '.mergeable')
+
+          # green 아닌 체크 수 (대기/실패/null 모두 카운트). 0 이면 전부 통과.
+          notgreen=$(gh pr view "$pr" -R "$REPO" --json statusCheckRollup --jq '
+            [.statusCheckRollup[] | (.conclusion // .state)]
+            | map(select(. == null or (. != "SUCCESS" and . != "NEUTRAL" and . != "SKIPPED")))
+            | length')
+
+          echo "mergeable=$mergeable, non-green checks=$notgreen"
+
+          if [ "$mergeable" = "MERGEABLE" ] && [ "$notgreen" = "0" ]; then
+            echo "→ 전부 green + mergeable → squash 머지 + 브랜치 삭제"
+            gh pr merge "$pr" -R "$REPO" --squash --delete-branch
+          else
+            echo "→ 아직 미충족(다른 체크 대기/실패 또는 conflict) — skip. 다음 CI 완료 시 재평가."
+          fi

--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="KotlinJpsPluginSettings">
-    <option name="version" value="2.0.21" />
+    <option name="externalSystemId" value="Gradle" />
+    <option name="version" value="2.3.0" />
   </component>
 </project>


### PR DESCRIPTION
## ✨ 작업 내용
PR 의 CI 가 모두 green + mergeable 이면 **서버측에서 자동 squash 머지**하는 GitHub Actions 워크플로 추가. Closes #108

- `.github/workflows/auto-merge.yml`: `workflow_run`(["Unit Test", "Static Analysis (Reviewdog)"], completed) → head SHA 의 열린 PR → 모든 체크 green + mergeable 이면 `gh pr merge --squash --delete-branch` (토큰 = `AUTOMERGE_PAT`)
- 네이티브 auto-merge 는 repo 설정(allow_auto_merge + 브랜치 보호)이 admin 권한을 요구 → collaborator(1hyok) 가 워크플로로 대체
- (`.idea/kotlinc.xml` 변경은 Kotlin 업그레이드 후 IDE 메타데이터 — 부수적)

## 📸 스크린샷 (선택)
- 해당 없음

## 🧪 테스트 방법
- **부트스트랩 PR**: main 에 워크플로가 아직 없어 본 PR 자체는 자동 머지 안 됨 → 수동 머지. 머지 후 **다음 PR 부터** 동작.
- 동작 전제: `AUTOMERGE_PAT` secret(1hyok PAT, scope `repo`+`workflow`) 등록 필요.

## 📝 TODO
- [ ] `AUTOMERGE_PAT` secret 등록 (미등록 시 워크플로는 실행되나 머지 step 만 실패 → PR 안 머지됨, 다른 영향 없음)

---

### ✅ PR 타입
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] UI 개선
- [x] 리팩토링
- [ ] 문서 작성

---

### 🔁 기타 참고 사항
- green PR 전부 자동 머지(라벨 게이트 미적용). `automerge` 라벨 조건은 추후 추가 가능.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
